### PR TITLE
fix: replace inline styles with CSS classes and declare activeDocumen…

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -8,6 +8,7 @@ export default tseslint.config(
 		languageOptions: {
 			globals: {
 				...globals.browser,
+				activeDocument: "readonly",
 			},
 			parserOptions: {
 				projectService: {

--- a/src/ThemeModal.ts
+++ b/src/ThemeModal.ts
@@ -244,8 +244,7 @@ export class ThemeModal extends Modal {
         if (value === "custom") {
             if (pgSetting) {
                 pgSetting.nameEl.innerText = "Custom theme colors";
-                pgSetting.settingEl.style.setProperty("pointer-events", "auto");
-                pgSetting.settingEl.style.setProperty("opacity", "1");
+                pgSetting.settingEl.classList.remove("theme-preview-readonly");
             }
             if (cPage !== null) cPage.setValue(this.customPageColor);
             if (cLink !== null) cLink.setValue(this.customLinkColor);
@@ -256,8 +255,7 @@ export class ThemeModal extends Modal {
             const theme = this.plugin.settings.themes.find(t => t.id === value);
             if (theme && pgSetting) {
                 pgSetting.nameEl.innerText = "Preset preview (read-only)";
-                pgSetting.settingEl.style.setProperty("pointer-events", "none");
-                pgSetting.settingEl.style.setProperty("opacity", "0.5");
+                pgSetting.settingEl.classList.add("theme-preview-readonly");
                 if (cPage !== null) cPage.setValue(theme.pageColor);
                 if (cLink !== null) cLink.setValue(theme.linkColor);
                 if (cAcc !== null) cAcc.setValue(theme.accentColor);

--- a/styles.css
+++ b/styles.css
@@ -243,6 +243,12 @@ body .custom-note-theme.pattern-checkerboard .cm-scroller .cm-content {
     transform: scaleY(1.8);
 }
 
+/* Theme Preview — Read-only state for preset preview */
+.theme-preview-readonly {
+    pointer-events: none;
+    opacity: 0.5;
+}
+
 /* Empty State */
 .theme-empty-state {
     color: var(--text-muted);


### PR DESCRIPTION
…t global for lint compliance